### PR TITLE
Swagger reshaping proposal for recommendation 20

### DIFF
--- a/docs/recommendation-20/swagger.yaml
+++ b/docs/recommendation-20/swagger.yaml
@@ -16,76 +16,40 @@ info:
 servers:
 - url: "https://codelists.api.edi3.org/recommendation-20"
 paths:
-  /quantityCategory:
+  /unitsOfMeasure/{commonCode}:
     get:
       tags:
-      - quantityCategory
-      summary: Search for units of measure as defined in rec 20
-      description: This api will return a (paged) list of units of measure codes
-      operationId: searchQuantityCategory
+      - unitsOfMeasure
+      summary: get a unit of measure from a code as defined in rec 20
+      description: "This api returns the details of a single unit of measure"
       parameters:
-      - name: GroupNumber
-        in: query
-        description: ""
-        schema:
+      - name: commonCode
+        in: path
+        required: true
+        schema: 
           type: string
-      - name: Sector
-        in: query
-        description: ""
-        schema:
-          type: string
-      - name: GroupID
-        in: query
-        description: ""
-        schema:
-          type: string
-      - name: Quantity
-        in: query
-        description: "The name of the physical phenomenon being measured"
-        schema:
-          type: string
-      - name: Level/Category
-        in: query
-        description: "Identification of the normative or informative relevance of the unit"
-        schema:
-          type: string
-      - name: Status
-        in: query
-        description: "An indication of the maintenance status of individual units of measure"
-        schema:
-          type: string
-      - name: CommonCode
-        in: query
-        description: "This is the recommended single list of standard codes"
-        schema:
-          type: string
-      - name: Name
-        in: query
-        description: "The name of the unit of measure"
-        schema:
-          type: string
-      - name: Description
-        in: query
-        description: "A plain text specification of the named unit of measure"
-        schema:
-          type: string
+        description: |
+          This is the recommended single list of standard codes which is based on the following conventions.
+          
+          The representation format for the code values shall be alphanumeric variable length 3 characters (an..3); wherever possible, existing code values are retained according to the following order of precedence for assigning values
+          
+            - (a) alphabetic code values for units of measure as in UN/ECE
+                Recommendation No. 20, edition 1985;
+                
+            - (b) alphanumeric code values for units of measure as in ANSI ASC X12 data
+              element number 355;
       responses:
         200:
-          description: OK
+          description: Successfull operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/QuantityCategories'
+                $ref: '#/components/schemas/UnitOfMeasure'
               example:
-              - GroupNumber: 01
-                Sector: Space and Time
-                GroupID: 17
-                Quantity: solid angle
-                Level/Category: 1S
-                Status: ""
-                CommonCode: M55
-                Name: metre per radiant
-                Description: Unit of the translation factor for implementation from rotation to linear movement.
+              - commonCode: 10
+                name: group
+                description: A unit of count defining the number of groups (group; set of items classified together).
+                category: 3.9
         400:
           description: ' Bad request - Issue with parameter'
           content:
@@ -103,7 +67,7 @@ paths:
                 $ref: '#/components/schemas/Error'
               example:
                 identifier: b1f1fef1-59ad-4978-bed8-3ff96d6d3587
-                error: No quantity measure found
+                error: No units of measure found
         500:
           description: Internal Server Error
           content:
@@ -113,46 +77,74 @@ paths:
               example:
                 identifier: 0407936e-d2ad-41e9-99e2-05a5919c3075
                 error: An unexpected exception occured
-  /unitOfMeasure:
+  /unitsOfMeasure:
     get:
       tags:
-      - unitOfMeasure
+      - unitsOfMeasure
       summary: Search for units of measure as defined in rec 20
       description: This api will return a (paged) list of units of measure codes
-      operationId: searchUnitOfMeasure
       parameters:
-      - name: CommonCode
-        in: query
-        description: "This is the recommended single list of standard codes"
-        schema:
-          type: string
-      - name: Name
+      - name: name
         in: query
         description: "The name of the unit of measure"
         schema:
           type: string
-      - name: Description
+      - name: description
         in: query
         description: "A plain text specification of the named unit of measure"
         schema:
           type: string
-      - name: Level/Category
+      - name: level
         in: query
-        description: "Identification of the normative or informative relevance of the unit"
+        description: |
+          Identification of the normative or informative relevance of the unit (Level / Category).
+
+          - Level 1 - normative = SI normative units, standard and commonly used multiples
+        
+                NOTE: standard multiples are identified with "S" and commonly used multiples with "M"
+                e.g. "1 metre", "1S centimetre", "1M hectometre").
+              
+          - Level 2 – normative equivalent = SI normative equivalent units (UK, US, etc.) and
+          commonly used multiples.
+          
+          - Level 3 – informative = 9 categories of informative units (units of count and other
+          miscellaneous units), invariably with no comprehensive conversion factor to SI.
+          These units are provided for information and to facilitate the assignment and usage of
+          a common code value to represent such units.
+            - 3.1 Qualified base units from levels 1 and 2
+            - 3.2 Sales units
+            - 3.3 Packing units
+            - 3.4 Shipping and transportation units
+            - 3.5 Industry specific units (various)
+            - 3.6 Information technology units
+            - 3.7 Integers/Numbers/Ratios
+            - 3.8 Multiples/Fractions/Decimals
+            - 3.9 Miscellaneous
         schema:
           type: string
+      - name: range  
+        description: Pagination parameter. default 0-49. Maximum rows to return 50
+        required: false
+        in: header
+        schema:
+            type: string
       responses:
         200:
-          description: OK
+          description: Successful Operation
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UnitsOfMeasure'
-              example:
-              - CommonCode: 10
-                Name: group
-                Description: A unit of count defining the number of groups (group; set of items classified together).
-                Level/Category: 3.9
+                items:
+                  $ref: '#/components/schemas/UnitOfMeasure'
+                type: array
+        206:
+          description: Successful Operation but partial content
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: '#/components/schemas/UnitOfMeasure'
+                type: array
         400:
           description: ' Bad request - Issue with parameter'
           content:
@@ -189,57 +181,85 @@ components:
           type: string
         error:
           type: string
-    QuantityCategories:
-      type: array
-      items:
-        $ref: '#/components/schemas/QuantityCategory'
-    QuantityCategory:
-      type: object
-      properties:
-        GroupNumber:
-          description: ""
-          type: string
-        Sector:
-          description: ""
-          type: string
-        GroupID:
-          description: ""
-          type: string
-        Quantity:
-          description: "The name of the physical phenomenon being measured"
-          type: string
-        Level/Category:
-          description: "Identification of the normative or informative relevance of the unit"
-          type: string
-        Status:
-          description: "An indication of the maintenance status of individual units of measure"
-          type: string
-        CommonCode:
-          description: "This is the recommended single list of standard codes"
-          type: string
-        Name:
-          description: "The name of the unit of measure"
-          type: string
-        Description:
-          description: "A plain text specification of the named unit of measure"
-          type: string
-    UnitsOfMeasure:
-      type: array
-      items:
-        $ref: '#/components/schemas/UnitOfMeasure'
     UnitOfMeasure:
       type: object
       properties:
-        CommonCode:
-          description: "This is the recommended single list of standard codes"
+        commonCode:
+          description: |
+            This is the recommended single list of standard codes which is based on the following conventions.
+          
+            The representation format for the code values shall be alphanumeric variable length 3 characters (an..3); wherever possible, existing code values are retained according to the following order of precedence for assigning values
+          
+            - (a) alphabetic code values for units of measure as in UN/ECE
+                Recommendation No. 20, edition 1985;
+                
+            - (b) alphanumeric code values for units of measure as in ANSI ASC X12 data
+              element number 355;
           type: string
-        Name:
+        name:
           description: "The name of the unit of measure"
           type: string
-        Description:
+        description:
           description: "A plain text specification of the named unit of measure"
           type: string
-        Level/Category:
-          description: "Identification of the normative or informative relevance of the unit"
+        level:
+          description: |
+            Identification of the normative or informative relevance of the unit (Level / Category).
+  
+            - Level 1 - normative = SI normative units, standard and commonly used multiples
+          
+                  NOTE: standard multiples are identified with "S" and commonly used multiples with "M"
+                  e.g. "1 metre", "1S centimetre", "1M hectometre").
+                
+            - Level 2 – normative equivalent = SI normative equivalent units (UK, US, etc.) and
+            commonly used multiples.
+            
+            - Level 3 – informative = 9 categories of informative units (units of count and other
+            miscellaneous units), invariably with no comprehensive conversion factor to SI.
+            These units are provided for information and to facilitate the assignment and usage of
+            a common code value to represent such units.
+              - 3.1 Qualified base units from levels 1 and 2
+              - 3.2 Sales units
+              - 3.3 Packing units
+              - 3.4 Shipping and transportation units
+              - 3.5 Industry specific units (various)
+              - 3.6 Information technology units
+              - 3.7 Integers/Numbers/Ratios
+              - 3.8 Multiples/Fractions/Decimals
+              - 3.9 Miscellaneous
+          type: string
+        sector:
+          description: "Name of the sector in plain english"
+          type: string
+        symbol:
+          description: "The symbol used to represent the unit of measure as in ISO 31 / 80000."
+          type: string
+        conversionFactor:
+          description: "Conversion factor to SI"
+          type: string
+        quantity:
+          description: |
+            The name of the physical phenomenon being measured.
+            
+            - (a) In levels 1 and 2 (SI or SI equivalent), the phenomena pertaining to a certain
+            category are listed under a heading giving the name of the relevant part in ISO 31;
+            - (b) In level 3 they are broken down into the 9 categories as defined below under
+            level/catgory.
+          type: string
+        status:
+          description: |
+            An indication of the maintenance status of individual units of measure
+              - a plus sign (+) Added. New unit added in this release of the code list
+              - a hash sign (#) Changed name. Changes to the unit name in this release of the
+              code list
+              - a vertical bar (¦) Changed characteristic(s). Changes other than to the unit name in
+              this release of the code list, e.g. a change to the level/category
+              - a letter D (D) Deprecated. Units not recommended for use by the Bureau
+              International des Poids et Mesures (BIPM)
+              - a letter X (X) Marked as deleted. Units marked as deleted will be retained
+              indefinitely in the code lists. When appropriate, these units may subsequently be
+              reinstated via the maintenance process
+              - an equals sign (=) Reinstated. Units previously marked as deleted and reinstated
+              in this release of the code list
           type: string
       


### PR DESCRIPTION
Reshaping proposal based on feedback and past experiences on designing referential API.

Hi, 
I’ve been thinking on the use cases that this API should answer to and I kinda re shaped it accordingly.
Please let me know how you feel about it.

I guess that /quantityCategory and /unitofmeasure were eventually two ways of accessing to the same resource, being the list of units of measure, from a restful perspective at least.

So here are the main updates I made :
-	Changed the name of the resource to make it a plural : unitsOfMeasure.
-	Update all parameters to camelCase
-	Changed the name of one parameter that had a slash in the middle, I’m afraid this could cause some trouble from an implementation perspective ( Level/Category  level). Also updated description to contain the old name as information.
-	I also added some descriptions based on the documentation from UN/CEFACT
-	I removed technical IDs such as 
                           groupID (Identifier (numeric ID) of the unit of measure, within the group)
                           groupNumber (Identifier (numeric ID) for the group/sector")
-	I added a path with the commonCode as path parameter
-	I removed some of the  parameter from input such as commonCode or description, considering that we would rather search by name or sector rather than code (which would then be accessed from the other path directly)
-	I added a specific input param for pagination and a specific error

Please comment,  react & challenge !
